### PR TITLE
Updated: změna textu při onToggleClick

### DIFF
--- a/ukol02/ukol02.js
+++ b/ukol02/ukol02.js
@@ -6,6 +6,8 @@ function onToggleClick(event) {
     for (const poznamka of poznamky) {
         poznamka.classList.toggle(HIDDEN_CLASS_NAME);
     }
+
+    event.currentTarget.textContent = event.currentTarget.textContent === "zobrazit poznámky" ? "skrýt poznámky" : "zobrazit poznámky";
 }
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
Po kliknutí na tlačítko s textem "skrýt poznámky" **musí** skript:

- skrýt pomocí CSS všechny odstavce s třídou poznámka
- **změnit text tlačítka na „zobrazit poznámky“** -  úprava tohoto bodu :)
- změnit chování tlačítka po kliknutí na odkrytí poznámek.